### PR TITLE
Space Traveler - Write Tests for Profile Rockets

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",
     "jest": "^27.5.1",

--- a/src/__tests__/Profile.test.js
+++ b/src/__tests__/Profile.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import {
+  render, screen, fireEvent, cleanup,
+} from '@testing-library/react';
 import renderer from 'react-test-renderer';
 import store from '../redux/ConfigureStore';
 import Profile from '../components/Profile/Profile';
@@ -19,7 +21,7 @@ const ProfileProvider = () => (
 );
 
 afterEach(() => {
-    cleanup();
+  cleanup();
 });
 
 describe('Check MyRockets', () => {
@@ -46,18 +48,18 @@ describe('Run tests on profile page functions', () => {
   it('persists the reservation made on the rockets component', () => {
     render(<ProfileProvider />);
     const profileRockets = screen.getByTestId('profileRockets');
-    expect(profileRockets.childElementCount).toBe(4)
+    expect(profileRockets.childElementCount).toBe(4);
   });
 
   it('removes the reserved rockets when clicked', async () => {
     render(<ProfileProvider />);
     const deleteButtons = await screen.findAllByRole('img');
     expect(deleteButtons.length).toBe(3);
-    
+
     fireEvent.click(deleteButtons[0]);
     fireEvent.click(deleteButtons[1]);
 
     const profileRockets = screen.getByTestId('profileRockets');
-    expect(profileRockets.childElementCount).toBe(2)
+    expect(profileRockets.childElementCount).toBe(2);
   });
 });

--- a/src/__tests__/Profile.test.js
+++ b/src/__tests__/Profile.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { render, screen, fireEvent, cleanup } from '@testing-library/react';
+import renderer from 'react-test-renderer';
+import store from '../redux/ConfigureStore';
+import Profile from '../components/Profile/Profile';
+import Rockets from '../components/Rockets/Rockets';
+
+const RocketsProvider = () => (
+  <Provider store={store}>
+    <Rockets />
+  </Provider>
+);
+
+const ProfileProvider = () => (
+  <Provider store={store}>
+    <Profile />
+  </Provider>
+);
+
+afterEach(() => {
+    cleanup();
+});
+
+describe('Check MyRockets', () => {
+  it('matches snapshot', () => {
+    const component = renderer.create(<ProfileProvider />).toJSON();
+    expect(component).toMatchSnapshot();
+  });
+});
+
+describe('Rockets Component', () => {
+  it('renders rockets and perform click of reservation button', async () => {
+    render(<RocketsProvider />);
+    const allRockets = await screen.findAllByText('Reserve Rocket');
+    expect(allRockets).toHaveLength(4);
+
+    const reserveButton = await screen.findAllByText(/Reserve Rocket/i);
+    fireEvent.click(reserveButton[0]);
+    fireEvent.click(reserveButton[1]);
+    fireEvent.click(reserveButton[2]);
+  });
+});
+
+describe('Run tests on profile page functions', () => {
+  it('persists the reservation made on the rockets component', () => {
+    render(<ProfileProvider />);
+    const profileRockets = screen.getByTestId('profileRockets');
+    expect(profileRockets.childElementCount).toBe(4)
+  });
+
+  it('removes the reserved rockets when clicked', async () => {
+    render(<ProfileProvider />);
+    const deleteButtons = await screen.findAllByRole('img');
+    expect(deleteButtons.length).toBe(3);
+    
+    fireEvent.click(deleteButtons[0]);
+    fireEvent.click(deleteButtons[1]);
+
+    const profileRockets = screen.getByTestId('profileRockets');
+    expect(profileRockets.childElementCount).toBe(2)
+  });
+});

--- a/src/__tests__/Rockets.test.js
+++ b/src/__tests__/Rockets.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { render, screen, fireEvent } from '@testing-library/react';
-import '@testing-library/jest-dom';
 import renderer from 'react-test-renderer';
 import store from '../redux/ConfigureStore';
 import Rockets from '../components/Rockets/Rockets';

--- a/src/__tests__/__snapshots__/Profile.test.js.snap
+++ b/src/__tests__/__snapshots__/Profile.test.js.snap
@@ -1,0 +1,35 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Check MyRockets matches snapshot 1`] = `
+<div
+  className="container"
+>
+  <ul
+    className="my-journeys"
+  >
+    <li>
+       
+      <h1>
+        My Missions
+      </h1>
+    </li>
+    <li>
+      No Missions joined yet
+    </li>
+  </ul>
+  <ul
+    className="my-journeys"
+    data-testid="profileRockets"
+  >
+    <li>
+       
+      <h1>
+        My Rockets
+      </h1>
+    </li>
+    <li>
+      No rocket reservations yet
+    </li>
+  </ul>
+</div>
+`;

--- a/src/components/Profile/MyRockets.js
+++ b/src/components/Profile/MyRockets.js
@@ -10,7 +10,7 @@ const MyRockets = ({ data }) => {
     dispatch(reserveRocket(id));
   };
   return (
-    <ul className={styles['my-journeys']}>
+    <ul className={styles['my-journeys']} data-testid="profileRockets">
       <li>
         {' '}
         <h1>My Rockets</h1>
@@ -22,7 +22,7 @@ const MyRockets = ({ data }) => {
           <li key={id}>
             <div className={styles.setItems}>
               <span>{rocketName}</span>
-              <BsFillTrashFill onClick={() => removeRocketHandler(id)} />
+              <BsFillTrashFill onClick={() => removeRocketHandler(id)} role="img" />
             </div>
           </li>
         ))


### PR DESCRIPTION
Hey @guerreiropedr0,

Here is my PR for the `testing of rockets in profile component'. In this branch I was able to achieve the following:

- Render the rocket component
- FireEvent on 3 reserve rocket button
- Render the profile component to check if the reservation of rockets persists by checking the count of elements on that `ul` that should harbor them
- FireEvent to remove 2 reservations and check the count on the parent list

Thank you so much for reviewing my PR 🏅;